### PR TITLE
Adds support for vscode remote container development.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+# This file defines a dev container used for app development.
+# TODO: Figure out how to set specific versions.
+
+FROM devillex/docker-firebase
+
+ENV USER=app
+
+RUN apt-get update && apt-get install -y \
+        git \
+        openssl \
+        libssl-dev \
+        bash \
+        less \
+        vim \
+        gnupg \
+        curl \
+        net-tools \
+        apt-transport-https \
+        ca-certificates; \
+    CLOUD_SDK_REPO="cloud-sdk-$(grep VERSION_CODENAME /etc/os-release | cut -d '=' -f 2)" &&\
+    echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list &&\
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -; \
+    apt-get update && apt-get install -y \
+        google-cloud-sdk \
+        google-cloud-sdk-cloud-build-local &&\
+    gcloud config set project request-a-dance
+    
+EXPOSE 5000 5001 9005

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/docker-existing-dockerfile
+{
+	"name": "Remote Container Dev Environment",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "Dockerfile",
+
+	// The optional 'runArgs' property can be used to specify additional runtime arguments.
+	"runArgs": [
+		// Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-in-docker for details.
+		// "-v","/var/run/docker.sock:/var/run/docker.sock",
+
+		// Uncomment the next line if you will be using a ptrace-based debugger like C++, Go, and Rust.
+		// "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
+
+		// You may want to add a non-root user to your Dockerfile. On Linux, this will prevent
+		// new files getting created as root. See https://aka.ms/vscode-remote/containers/non-root-user
+		// for the needed Dockerfile updates and then uncomment the next line.
+		// "-u", "vscode"
+	],
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		// This will ignore your local shell user setting for Linux since shells like zsh are typically 
+		// not in base container images. You can also update this to an specific shell to ensure VS Code 
+		// uses the right one for terminals and tasks. For example, /bin/bash (or /bin/ash for Alpine).
+		"terminal.integrated.shell.linux": null
+	},
+
+	// Uncomment the next line if you want to publish any ports.
+	"forwardPorts": [5000, 5001, 9005],
+
+	// Uncomment the next line to run commands after the container is created - for example installing git.
+	// "postCreateCommand": "apt-get update && apt-get install -y git",
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"xabikos.JavaScriptSnippets", 
+		"christian-kohler.npm-intellisense",
+		"msjsdiag.debugger-for-chrome",
+		"huizhou.githd",
+		"johnpapa.vscode-peacock",
+		"mfery.gitexplorer"
+	]
+}

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
In this setup the container image contains all the project dependencies
(i.e. Nodejs and Firebase) in addition to developer tool (git and useful
vscode extensions).

CAVEATS:

1. Port Forwarding: This config permanently forwards a few ports. In
   particular, port 9005 is used for logging into Firebase.

2. You'll probably want to have at least vscode 1.49.2 as it did not
   work until after I did an upgrade. For posterity, here's my current
   setup:

	Version: 1.49.2
	Commit: e5e9e69aed6e1984f7499b7af85b3d05f9a6883a
	Date: 2020-09-24T16:26:09.944Z
	Electron: 9.2.1
	Chrome: 83.0.4103.122
	Node.js: 12.14.1
	V8: 8.3.110.13-electron.0
	OS: Linux x64 5.7.17-1rodete1-amd64

More info on the setup and how to use remote container dev can be found here:
https://docs.google.com/document/d/1Xg-S2mHdZWH8DuxcAkmXzYhZCj2Q4Ls4rpdrH1Bo940/edit?usp=sharing